### PR TITLE
Apache config order

### DIFF
--- a/engine/PerlLib/Servers/httpd/apache_fcgid.pm
+++ b/engine/PerlLib/Servers/httpd/apache_fcgid.pm
@@ -356,7 +356,7 @@ sub deleteDmn($$)
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1605,7 +1605,12 @@ sub _addCfg($$)
 	$self->setData($data);
 
 	# Disable and backup Apache sites if any
-	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
+	for(
+		"$data->{'DOMAIN_NAME'}.conf",
+		"$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$data->10_{'DOMAIN_NAME'}.conf",
+		"$data->10_{'DOMAIN_NAME'}_ssl.conf"
+	) {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 
@@ -1619,8 +1624,12 @@ sub _addCfg($$)
 
 	# Remove previous Apache sites if any
 	for(
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {

--- a/engine/PerlLib/Servers/httpd/apache_fcgid.pm
+++ b/engine/PerlLib/Servers/httpd/apache_fcgid.pm
@@ -345,18 +345,18 @@ sub deleteDmn($$)
 	return $rs if $rs;
 
 	# Disable apache site files
-	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
+	for("10_$data->{'DOMAIN_NAME'}.conf", "10_$data->{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 	}
 
 	# Remove apache site files
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1608,8 +1608,8 @@ sub _addCfg($$)
 	for(
 		"$data->{'DOMAIN_NAME'}.conf",
 		"$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$data->10_{'DOMAIN_NAME'}.conf",
-		"$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"10_$data->{'DOMAIN_NAME'}.conf",
+		"10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
@@ -1626,12 +1626,12 @@ sub _addCfg($$)
 	for(
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1640,10 +1640,10 @@ sub _addCfg($$)
 	# Build Apache sites - Begin
 
 	my %configs;
-	$configs{"$data->10_{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
+	$configs{"10_$data->{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
 
 	if($data->{'SSL_SUPPORT'}) {
-		$configs{"$data->10_{'DOMAIN_NAME'}_ssl.conf"} = {
+		$configs{"10_$data->{'DOMAIN_NAME'}_ssl.conf"} = {
 			'redirect' => 'domain_redirect_ssl.tpl', 'normal' => 'domain_ssl.tpl'
 		};
 

--- a/engine/PerlLib/Servers/httpd/apache_fcgid.pm
+++ b/engine/PerlLib/Servers/httpd/apache_fcgid.pm
@@ -345,18 +345,18 @@ sub deleteDmn($$)
 	return $rs if $rs;
 
 	# Disable apache site files
-	for("$data->{'DOMAIN_NAME'}.conf", "$data->{'DOMAIN_NAME'}_ssl.conf") {
+	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 	}
 
 	# Remove apache site files
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1605,7 +1605,7 @@ sub _addCfg($$)
 	$self->setData($data);
 
 	# Disable and backup Apache sites if any
-	for("$data->{'DOMAIN_NAME'}.conf", "$data->{'DOMAIN_NAME'}_ssl.conf") {
+	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 
@@ -1619,10 +1619,10 @@ sub _addCfg($$)
 
 	# Remove previous Apache sites if any
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1631,10 +1631,10 @@ sub _addCfg($$)
 	# Build Apache sites - Begin
 
 	my %configs;
-	$configs{"$data->{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
+	$configs{"$data->10_{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
 
 	if($data->{'SSL_SUPPORT'}) {
-		$configs{"$data->{'DOMAIN_NAME'}_ssl.conf"} = {
+		$configs{"$data->10_{'DOMAIN_NAME'}_ssl.conf"} = {
 			'redirect' => 'domain_redirect_ssl.tpl', 'normal' => 'domain_ssl.tpl'
 		};
 

--- a/engine/PerlLib/Servers/httpd/apache_itk.pm
+++ b/engine/PerlLib/Servers/httpd/apache_itk.pm
@@ -345,18 +345,18 @@ sub deleteDmn($$)
 	return $rs if $rs;
 
 	# Disable apache site files
-	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
+	for("10_$data->{'DOMAIN_NAME'}.conf", "10_$data->{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 	}
 
 	# Remove apache site files
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1545,8 +1545,8 @@ sub _addCfg($$)
 	for(
 		"$data->{'DOMAIN_NAME'}.conf",
 		"$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$data->10_{'DOMAIN_NAME'}.conf",
-		"$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"10_$data->{'DOMAIN_NAME'}.conf",
+		"10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
@@ -1563,12 +1563,12 @@ sub _addCfg($$)
 	for(
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1577,10 +1577,10 @@ sub _addCfg($$)
 	# Build Apache sites - Begin
 
 	my %configs;
-	$configs{"$data->10_{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
+	$configs{"10_$data->{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
 
 	if($data->{'SSL_SUPPORT'}) {
-		$configs{"$data->10_{'DOMAIN_NAME'}_ssl.conf"} = {
+		$configs{"10_$data->{'DOMAIN_NAME'}_ssl.conf"} = {
 			'redirect' => 'domain_redirect_ssl.tpl', 'normal' => 'domain_ssl.tpl'
 		};
 

--- a/engine/PerlLib/Servers/httpd/apache_itk.pm
+++ b/engine/PerlLib/Servers/httpd/apache_itk.pm
@@ -356,7 +356,7 @@ sub deleteDmn($$)
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1542,7 +1542,12 @@ sub _addCfg($$)
 	$self->setData($data);
 
 	# Disable and backup Apache sites if any
-	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
+	for(
+		"$data->{'DOMAIN_NAME'}.conf",
+		"$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$data->10_{'DOMAIN_NAME'}.conf",
+		"$data->10_{'DOMAIN_NAME'}_ssl.conf"
+	) {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 
@@ -1556,8 +1561,12 @@ sub _addCfg($$)
 
 	# Remove previous Apache sites if any
 	for(
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {

--- a/engine/PerlLib/Servers/httpd/apache_itk.pm
+++ b/engine/PerlLib/Servers/httpd/apache_itk.pm
@@ -345,18 +345,18 @@ sub deleteDmn($$)
 	return $rs if $rs;
 
 	# Disable apache site files
-	for("$data->{'DOMAIN_NAME'}.conf", "$data->{'DOMAIN_NAME'}_ssl.conf") {
+	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 	}
 
 	# Remove apache site files
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1542,7 +1542,7 @@ sub _addCfg($$)
 	$self->setData($data);
 
 	# Disable and backup Apache sites if any
-	for("$data->{'DOMAIN_NAME'}.conf", "$data->{'DOMAIN_NAME'}_ssl.conf") {
+	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 
@@ -1556,10 +1556,10 @@ sub _addCfg($$)
 
 	# Remove previous Apache sites if any
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1568,10 +1568,10 @@ sub _addCfg($$)
 	# Build Apache sites - Begin
 
 	my %configs;
-	$configs{"$data->{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
+	$configs{"$data->10_{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
 
 	if($data->{'SSL_SUPPORT'}) {
-		$configs{"$data->{'DOMAIN_NAME'}_ssl.conf"} = {
+		$configs{"$data->10_{'DOMAIN_NAME'}_ssl.conf"} = {
 			'redirect' => 'domain_redirect_ssl.tpl', 'normal' => 'domain_ssl.tpl'
 		};
 

--- a/engine/PerlLib/Servers/httpd/apache_php_fpm.pm
+++ b/engine/PerlLib/Servers/httpd/apache_php_fpm.pm
@@ -354,18 +354,18 @@ sub deleteDmn($$)
 	return $rs if $rs;
 
 	# Disable apache site files
-	for("$data->{'DOMAIN_NAME'}.conf", "$data->{'DOMAIN_NAME'}_ssl.conf") {
+	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 	}
 
 	# Remove apache site files
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'phpfpmConfig'}->{'PHP_FPM_POOLS_CONF_DIR'}/$data->{'DOMAIN_NAME'}.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
@@ -1735,7 +1735,7 @@ sub _addCfg($$)
 	$self->setData($data);
 
 	# Disable and backup Apache sites if any
-	for("$data->{'DOMAIN_NAME'}.conf", "$data->{'DOMAIN_NAME'}_ssl.conf"){
+	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf"){
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 
@@ -1745,10 +1745,10 @@ sub _addCfg($$)
 
 	# Remove previous Apache sites if any
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1757,10 +1757,10 @@ sub _addCfg($$)
 	# Build Apache sites - Begin
 
 	my %configs;
-	$configs{"$data->{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
+	$configs{"$data->10_{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
 
 	if($data->{'SSL_SUPPORT'}) {
-		$configs{"$data->{'DOMAIN_NAME'}_ssl.conf"} = {
+		$configs{"$data->10_{'DOMAIN_NAME'}_ssl.conf"} = {
 			'redirect' => 'domain_redirect_ssl.tpl', 'normal' => 'domain_ssl.tpl'
 		};
 

--- a/engine/PerlLib/Servers/httpd/apache_php_fpm.pm
+++ b/engine/PerlLib/Servers/httpd/apache_php_fpm.pm
@@ -1735,7 +1735,12 @@ sub _addCfg($$)
 	$self->setData($data);
 
 	# Disable and backup Apache sites if any
-	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf"){
+	for(
+		"$data->{'DOMAIN_NAME'}.conf",
+		"$data->{'DOMAIN_NAME'}_ssl.conf",
+		"$data->10_{'DOMAIN_NAME'}.conf",
+		"$data->10_{'DOMAIN_NAME'}_ssl.conf"
+	) {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 
@@ -1745,8 +1750,12 @@ sub _addCfg($$)
 
 	# Remove previous Apache sites if any
 	for(
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
 	) {

--- a/engine/PerlLib/Servers/httpd/apache_php_fpm.pm
+++ b/engine/PerlLib/Servers/httpd/apache_php_fpm.pm
@@ -354,18 +354,18 @@ sub deleteDmn($$)
 	return $rs if $rs;
 
 	# Disable apache site files
-	for("$data->10_{'DOMAIN_NAME'}.conf", "$data->10_{'DOMAIN_NAME'}_ssl.conf") {
+	for("10_$data->{'DOMAIN_NAME'}.conf", "10_$data->{'DOMAIN_NAME'}_ssl.conf") {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
 	}
 
 	# Remove apache site files
 	for(
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'config'}->{'APACHE_CUSTOM_SITES_CONFIG_DIR'}/$data->{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'phpfpmConfig'}->{'PHP_FPM_POOLS_CONF_DIR'}/$data->{'DOMAIN_NAME'}.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
@@ -1738,8 +1738,8 @@ sub _addCfg($$)
 	for(
 		"$data->{'DOMAIN_NAME'}.conf",
 		"$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$data->10_{'DOMAIN_NAME'}.conf",
-		"$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"10_$data->{'DOMAIN_NAME'}.conf",
+		"10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = $self->disableSite($_) if -f "$self->{'config'}->{'APACHE_SITES_DIR'}/$_";
 		return $rs if $rs;
@@ -1752,12 +1752,12 @@ sub _addCfg($$)
 	for(
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'config'}->{'APACHE_SITES_DIR'}/$data->10_{'DOMAIN_NAME'}_ssl.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'config'}->{'APACHE_SITES_DIR'}/10_$data->{'DOMAIN_NAME'}_ssl.conf",
 		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}.conf",
 		"$self->{'apacheWrkDir'}/$data->{'DOMAIN_NAME'}_ssl.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}.conf",
-		"$self->{'apacheWrkDir'}/$data->10_{'DOMAIN_NAME'}_ssl.conf"
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}.conf",
+		"$self->{'apacheWrkDir'}/10_$data->{'DOMAIN_NAME'}_ssl.conf"
 	) {
 		$rs = iMSCP::File->new('filename' => $_)->delFile() if -f $_;
 		return $rs if $rs;
@@ -1766,10 +1766,10 @@ sub _addCfg($$)
 	# Build Apache sites - Begin
 
 	my %configs;
-	$configs{"$data->10_{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
+	$configs{"10_$data->{'DOMAIN_NAME'}.conf"} = { 'redirect' => 'domain_redirect.tpl', 'normal' => 'domain.tpl' };
 
 	if($data->{'SSL_SUPPORT'}) {
-		$configs{"$data->10_{'DOMAIN_NAME'}_ssl.conf"} = {
+		$configs{"10_$data->{'DOMAIN_NAME'}_ssl.conf"} = {
 			'redirect' => 'domain_redirect_ssl.tpl', 'normal' => 'domain_ssl.tpl'
 		};
 


### PR DESCRIPTION
If you set an domain like 000abc.com the domain has a higher priority
than apaches 00_master.conf. Because of that the server default page
will be the domain 000abc.com instead of the imscp control panel.

This patch will change the apache config names from `domain.conf` to `10_domain.conf`. So the order should be correct again.

**Atm I had no test server, so I couldn't test the changes.**
