### PR TITLE
Network stop logs are deleted on imscp_network restart

### DIFF
--- a/configs/debian/init.d/imscp_network
+++ b/configs/debian/init.d/imscp_network
@@ -116,7 +116,7 @@ remove_rules() {
 }
 
 add_local_dns_resolver() {
-	${ENGINETOOLSPATH}/${LOCALDNSRESOLVER} start >${LOGDIR}/${LOCALDNSRESOLVER}.log 2>&1
+	${ENGINETOOLSPATH}/${LOCALDNSRESOLVER} start >>${LOGDIR}/${LOCALDNSRESOLVER}.log 2>&1
 }
 
 delete_local_dns_resolver() {
@@ -124,7 +124,7 @@ delete_local_dns_resolver() {
 }
 
 add_interfaces() {
-	${ENGINETOOLSPATH}/${NETWORKCARDMANAGER} start >${LOGDIR}/${NETWORKCARDMANAGER}.log 2>&1
+	${ENGINETOOLSPATH}/${NETWORKCARDMANAGER} start >>${LOGDIR}/${NETWORKCARDMANAGER}.log 2>&1
 }
 
 remove_interfaces() {


### PR DESCRIPTION
Many setup operations do a  imscp_network restart, in those case only the start logs were saved in ${LOGDIR}/${LOCALDNSRESOLVER}.log, with this patch, those logs are only recreated on stop
