### PR TITLE
Format mail_forward entries as multiline

### DIFF
--- a/gui/public/client/mail_edit.php
+++ b/gui/public/client/mail_edit.php
@@ -287,7 +287,7 @@ function client_generatePage($tpl)
 			'QUOTA' => isset($_POST['quota']) ? tohtml($_POST['quota']) : ($quota !== NULL ? floor($mailData['quota'] / 1048576) : ''),
 			'FORWARD_LIST' => isset($_POST['forward_list'])
 				? tohtml($_POST['forward_list'])
-				: ($mailData['mail_forward'] != '_no_' ? tohtml($mailData['mail_forward']) : '')
+				: ($mailData['mail_forward'] != '_no_' ? tohtml(str_replace(",", "\n", $mailData['mail_forward'])) : '')
 		)
 	);
 


### PR DESCRIPTION
In the current i-mscp stable, mail_forward entries
are displayed as comma-separated.

Displaying entries on a separate line improves
legibility.
