### PR TITLE
Added client connection settings

### DIFF
--- a/configs/debian/mysql/.my.cnf
+++ b/configs/debian/mysql/.my.cnf
@@ -1,3 +1,9 @@
+[client]
+host={DATABASE_HOST}
+port={DATABASE_PORT}
+user={DATABASE_USER}
+password={DATABASE_PASSWORD}
+
 [mysqldump]
 host={DATABASE_HOST}
 port={DATABASE_PORT}


### PR DESCRIPTION
Installer always overwrites my MySQL client settings. Two possible ways to solve this problem:
1.) Don't touch /root/.my.cnf
2.) Include client setting in /root/.my.cnf
