### PR TITLE
Fixed typo which causes in 404

### DIFF
--- a/docs/vagrant/Vagrantfile
+++ b/docs/vagrant/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vb, override|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
     override.vm.box = "jessie64"
-    override.vm.box_url = "https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.7.0/provider/virtualbox.box"
+    override.vm.box_url = "https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.7.0/providers/virtualbox.box"
   end
 
   config.vm.provider :lxc do |lxc, override|


### PR DESCRIPTION
URL needs to be "providers" instead of "provider" otherwise you will get the following error:

```
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'jessie64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'jessie64' (v0) for provider: virtualbox
    default: Downloading: https://atlas.hashicorp.com/debian/boxes/jessie64/versions/8.7.0/provider/virtualbox.box
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 404 Not Found
```
