### PR TITLE
Fix master/slave comments in preseed.pl

### DIFF
--- a/docs/preseed.pl
+++ b/docs/preseed.pl
@@ -236,7 +236,7 @@
     # Leave empty for default: master
     BIND_MODE                           => '',
 
-    # Primary DNS server IP addresses (only relevant with master mode)
+    # Primary DNS server IP addresses (only relevant with slave mode)
     #
     # Possible value: 'no' or a list of IPv4/IPv6 each separated by semicolon
     # or space
@@ -244,7 +244,7 @@
     # Leave empty for default: no
     PRIMARY_DNS                         => '',
 
-    # Slave DNS server IP addresses (only relevant with slave mode)
+    # Slave DNS server IP addresses (only relevant with master mode)
     #
     # Possible value: 'no' or a list of IPv4/IPv6 each separated by semicolon
     # or space


### PR DESCRIPTION
Contrary to what the documentation stated, the `PRIMARY_DNS` variable only applies in `slave` mode, whereas `SECONARY_DNS` applies only in `master` mode.