### PR TITLE
Fix typo in the vsftpd logrotate configuration

### DIFF
--- a/configs/debian/vsftpd/vsftpd
+++ b/configs/debian/vsftpd/vsftpd
@@ -17,7 +17,7 @@
 
 /var/log/xferlog
 {
-    dayly
+    daily
     missingok
     rotate 1
     nocompress


### PR DESCRIPTION
My test installation just e-mailed me the following error, which is caused by that typo:
```
/etc/cron.daily/logrotate:
error: vsftpd:18 unknown option 'dayly' -- ignoring line
```
