### PR TITLE
Increase session cookie safety

### DIFF
--- a/gui/library/iMSCP/Application.php
+++ b/gui/library/iMSCP/Application.php
@@ -278,6 +278,8 @@ class Application
             'use_only_cookies'    => 'on',
             'use_trans_sid'       => 'off',
             'strict'              => false,
+            'cookie_secure'       => true,
+            'cookie_httponly'     => true,
             'remember_me_seconds' => 0,
             'name'                => 'iMSCP_Session',
             'gc_divisor'          => 100,


### PR DESCRIPTION
Activate both secure cookie and HTTP only. SameSite is not available
before PHP7.3.0. Sadly, I had no option to activate cookie_secure only
if NGINX has been configured for HTTPS. Thanks to LetsEncrypt certs
this should not be to much risk.