### PR TITLE
give sql-backup files "speaking" names

### DIFF
--- a/engine/backup/imscp-backup-all
+++ b/engine/backup/imscp-backup-all
@@ -166,10 +166,14 @@ sub backupDatabases
         # Encode dots as Full stop unicode character
         ( my $encodedDbName = $dbName ) =~ s%([./])%{ '/', '@002f', '.', '@002e' }->{$1}%ge;
         my $dbDumpFilePath = File::Spec->catfile( $bkpDir, $encodedDbName . '.sql' );
+        my $bkpDate = strftime "%Y.%m.%d-%H-%M", localtime( );
+        my $bkpArchPath = File::Spec->catfile( $bkpDir, 'sql-backup-'.$encodedDbName.'-'.$bkpDate.'.sql' );
 
         my $file = iMSCP::File->new( filename => $dbDumpFilePath );
         my $rs = $file->owner( $user, $group );
         $rs ||= $file->mode( 0640 );
+        $rs ||= $file->moveFile( $bkpArchPath );
+        $dbDumpFilePath = $bkpArchPath;
 
         next if $rs || $cmpAlgo eq 'no';
 


### PR DESCRIPTION
Hello Nuxwin,
I already posted the changes in i-mscp forum conversation:

output of backup:
-rw-r----- 1 vu2005 vu2005       115 Oct 10 23:50 mail-backup-git.xxxxx.de-2017.10.10-23-50.tar.bz2
-rw-r----- 1 vu2005 vu2005 525133732 Oct 10 23:51 mail-backup-xxxxx.de-2017.10.10-23-50.tar.bz2
-rw-r----- 1 root   vu2005       636 Oct 10 23:50 sql-backup-huginn-2017.10.10-23-50.sql.bz2

Probably you can integrate it in 1.6.