### PR TITLE
Fix credential check in mysql installer

### DIFF
--- a/engine/PerlLib/Servers/sqld/mysql/installer.pm
+++ b/engine/PerlLib/Servers/sqld/mysql/installer.pm
@@ -349,8 +349,8 @@ sub _askSqlRootUser
         # If authentication is made through unix socket, password is normally not required.
         # We try a connect without password with 'root' as user and we return on success
         for my $host ( 'localhost', '127.0.0.1' ) {
-            next if $self->_tryDbConnect( $host, $port, $user, $pwd );
-            ::setupSetQuestion( 'DATABASE_HOST', $_ );
+            next if !$self->_tryDbConnect( $host, $port, $user, $pwd );
+            ::setupSetQuestion( 'DATABASE_HOST', $host );
             ::setupSetQuestion( 'DATABASE_PORT', $port );
             ::setupSetQuestion( 'SQL_ROOT_USER', $user );
             ::setupSetQuestion( 'SQL_ROOT_PASSWORD', $pwd );


### PR DESCRIPTION
I suspect this comparison was reversed from the intended one. It made my installation fail complaining about invalid preseed values because of it.