### PR TITLE
Several fixes for debian-buster

### DIFF
--- a/autoinstaller/Adapter/managed_services.txt
+++ b/autoinstaller/Adapter/managed_services.txt
@@ -13,6 +13,7 @@ php7.1-fpm
 php7.2-fpm
 php7.3-fpm
 php7.4-fpm
+php8.0-fpm
 postfix
 proftpd
 vsftpd

--- a/autoinstaller/Packages/debian-buster.xml
+++ b/autoinstaller/Packages/debian-buster.xml
@@ -157,6 +157,8 @@
             <package>php7.0-xml</package>
             <package>php7.0-zip</package>
             <package>libapache2-mod-php7.0</package>
+            <package>php7.0-apcu</package>
+            <package>php7.0-apcu-bc</package>
         </php7.0>
         <php7.1
                 always_installed="1"
@@ -195,6 +197,8 @@
             <package>php7.1-xml</package>
             <package>php7.1-zip</package>
             <package>libapache2-mod-php7.1</package>
+            <package>php7.1-apcu</package>
+            <package>php7.1-apcu-bc</package>
         </php7.1>
         <php7.2
                 always_installed="1"
@@ -232,6 +236,8 @@
             <package>php7.2-xml</package>
             <package>php7.2-zip</package>
             <package>libapache2-mod-php7.2</package>
+            <package>php7.2-apcu</package>
+            <package>php7.2-apcu-bc</package>
         </php7.2>
         <php7.3
                 always_installed="1"
@@ -285,6 +291,8 @@
             <package>php7.3-xml</package>
             <package>php7.3-zip</package>
             <package>libapache2-mod-php7.3</package>
+            <package>php7.3-apcu</package>
+            <package>php7.3-apcu-bc</package>
         </php7.3>
         <php7.4
                 always_installed="1"
@@ -322,9 +330,45 @@
             <package>php7.4-xml</package>
             <package>php7.4-zip</package>
             <package>libapache2-mod-php7.4</package>
+            <package>php7.4-apcu</package>
+            <package>php7.4-apcu-bc</package>
         </php7.4>
-        <package>php-apcu</package>
-        <package>php-apcu-bc</package>
+        <php8.0
+                always_installed="1"
+                class="Servers::php"
+                description="PHP 8.0"
+        >
+            <package
+                    post_install_tasks="
+                        /usr/sbin/phpenmod -v 8.0 -s ALL ctype fileinfo ftp
+                        gettext iconv pdo phar posix sockets bcmath bz2 curl gd
+                        gmp imap intl json mbstring mysqlnd mysqli pdo_mysql
+                        opcache pspell dom xml xmlreader xmlwriter zip apcu
+                    "
+            >
+                php8.0
+            </package>
+            <package>php8.0-cli</package>
+            <package>php8.0-cgi</package>
+            <package>php8.0-fpm</package>
+            <package>php8.0-common</package>
+            <package>php8.0-bcmath</package>
+            <package>php8.0-bz2</package>
+            <package>php8.0-curl</package>
+            <package>php8.0-gd</package>
+            <package>php8.0-gmp</package>
+            <package>php8.0-imap</package>
+            <package>php8.0-intl</package>
+            <package>php8.0-mbstring</package>
+            <package>php8.0-mysql</package>
+            <package>php8.0-opcache</package>
+            <package>php8.0-phar</package>
+            <package>php8.0-pspell</package>
+            <package>php8.0-xml</package>
+            <package>php8.0-zip</package>
+            <package>libapache2-mod-php8.0</package>
+            <package>php8.0-apcu</package>
+        </php8.0>
         <package>php-pear</package>
     </php>
     <po
@@ -489,7 +533,6 @@
         <package>libdatetime-perl</package>
         <package>libdbd-mariadb-perl</package>
         <package>libdbi-perl</package>
-        <package>libdigest-md5-perl</package>
         <package>libemail-valid-perl</package>
         <package>libfile-chmod-perl</package>
         <package>libfile-copy-recursive-perl</package>

--- a/engine/PerlLib/Package/ServicesSSL.pm
+++ b/engine/PerlLib/Package/ServicesSSL.pm
@@ -84,7 +84,7 @@ sub registerSetupListeners
 
 sub preinstall
 {
-    my $sslEnabled = ::setupGetQuestion( 'SERVICE_SSL_ENABLED' );
+    my $sslEnabled = ::setupGetQuestion( 'SERVICES_SSL_ENABLED' );
 
     # SSL is disabled. We need remove the SSL certificate if any and
     # return early

--- a/engine/PerlLib/Package/WebmailClients/Roundcube/Roundcube.pm
+++ b/engine/PerlLib/Package/WebmailClients/Roundcube/Roundcube.pm
@@ -43,7 +43,7 @@ use subs qw/
 /;
 
 my $packageVersionConstraint = $ENV{'IMSCP_PKG_DEVELOPMENT'}
-    ? '1.3.x-dev' : '^1.0';
+    ? '1.3.x-dev' : '1.3.x-dev';
 
 =head1 DESCRIPTION
 

--- a/engine/PerlLib/Servers/httpd/apache_fcgid/installer.pm
+++ b/engine/PerlLib/Servers/httpd/apache_fcgid/installer.pm
@@ -432,7 +432,7 @@ sub _buildFastCgiConfFiles
     $rs = $self->{'httpd'}->disableModules(
         'actions', 'fastcgi', 'fcgid', 'fcgid_imscp', 'php5', 'php5_cgi',
         'php5filter',
-        'php5.6', 'php7.0', 'php7.1', 'php7.2', 'php7.3', 'php7.4',
+        'php5.6', 'php7.0', 'php7.1', 'php7.2', 'php7.3', 'php7.4', 'php8.0'
         'proxy_fcgi', 'proxy_handler', 'mpm_itk', 'mpm_event', 'mpm_prefork',
         'mpm_worker'
     );
@@ -532,6 +532,7 @@ sub _buildApacheConfFiles
         'php7.2-cgi.conf', 'php7.2-fpm.conf',
         'php7.3-cgi.conf', 'php7.3-fpm.conf',
         'php7.4-cgi.conf', 'php7.4-fpm.conf',
+        'php8.0-cgi.conf', 'php8.0-fpm.conf',
         'serve-cgi-bin.conf'
     );
     $rs ||= $self->{'httpd'}->disableSites(

--- a/engine/PerlLib/Servers/httpd/apache_php_fpm/installer.pm
+++ b/engine/PerlLib/Servers/httpd/apache_php_fpm/installer.pm
@@ -446,7 +446,7 @@ sub _buildFastCgiConfFiles
     $rs = $self->{'httpd'}->disableModules(
         'actions', 'fastcgi', 'fcgid', 'fcgid_imscp', 'suexec',
         'php5', 'php5_cgi', 'php5filter',
-        'php5.6', 'php7.0', 'php7.1', 'php7.2', 'php7.3', 'php7.4',
+        'php5.6', 'php7.0', 'php7.1', 'php7.2', 'php7.3', 'php7.4', 'php8.0',
         'proxy_fcgi', 'proxy_handler', 'mpm_itk', 'mpm_event', 'mpm_prefork',
         'mpm_worker'
     );
@@ -589,6 +589,7 @@ sub _buildApacheConfFiles
         'php7.2-cgi.conf', 'php7.2-fpm.conf',
         'php7.3-cgi.conf', 'php7.3-fpm.conf',
         'php7.4-cgi.conf', 'php7.4-fpm.conf',
+        'php8.0-cgi.conf', 'php8.0-fpm.conf',
         'serve-cgi-bin.conf'
     );
     $rs ||= $self->{'httpd'}->disableSites(


### PR DESCRIPTION
- Add php8.0
- Fix ServicesSSL typo in SERVICES_SSL
- Temporary fix for Roundcube out of date dependency no longer available
  therefore use later (development) version.
- Add apache_fcgid installer