### PR TITLE
fix sql syntax error

### DIFF
--- a/engine/PerlLib/Package/ServicesSSL.pm
+++ b/engine/PerlLib/Package/ServicesSSL.pm
@@ -84,7 +84,7 @@ sub registerSetupListeners
 
 sub preinstall
 {
-    my $sslEnabled = ::setupGetQuestion( 'SERVICE_SSL_ENABLED' );
+    my $sslEnabled = ::setupGetQuestion( 'SERVICES_SSL_ENABLED' );
 
     # SSL is disabled. We need remove the SSL certificate if any and
     # return early

--- a/gui/src/Update/DatabaseUpdate.php
+++ b/gui/src/Update/DatabaseUpdate.php
@@ -2508,7 +2508,7 @@ class DatabaseUpdate extends AbstractUpdate
             $this->changeColumn(
                 'server_traffic',
                 'traff_time',
-                '`traff_time INT(10) UNSIGNED NOT NULL`'
+                '`traff_time` INT(10) UNSIGNED NOT NULL'
             ),
             $this->addIndex('server_traffic', 'traff_time')
         ];


### PR DESCRIPTION
sql syntax error : `` '`traff_time INT(10) UNSIGNED NOT NULL`'``, only the field name should be surrounded with backstick