### PR TITLE
Add '_' to plugin name validation

### DIFF
--- a/gui/src/Plugin/Validate/PluginArchive.php
+++ b/gui/src/Plugin/Validate/PluginArchive.php
@@ -289,7 +289,7 @@ class PluginArchive extends Zend_Validate_Abstract
             switch ($field) {
                 case 'name':
                     if (!is_string($info[$field])
-                        || !preg_match('/^[a-z]+$/i', $info[$field])
+                        || !preg_match('/^[a-z_]+$/i', $info[$field])
                     ) {
                         return $this->_throw(
                             $field, self::INVALID_PLUGIN_INFO_FIELD


### PR DESCRIPTION
Plugins with '_' in the name worked in the 1.5.3 release.

- The plugin name validator introduced in e76dfd672 did not allow for '_'
  in plugin names.

My plugins include a prefix in the name, like SGW_LetsEncrypt to distinguish them from other, similarly named plugins. Having the '_' be allowed in the name would be very helpful for this use.