### PR TITLE
Fix paths for lostpassword

### DIFF
--- a/gui/include/LostPassword.php
+++ b/gui/include/LostPassword.php
@@ -62,7 +62,7 @@ function createImage($strSessionVar)
     );
 
     for ($i = 0; $i < $nbLetters; $i++) {
-        $fontFile = LIBRARY_PATH . '/Resources/Fonts/'
+        $fontFile = GUI_ROOT_DIR . '/resources/fonts/'
             . $cfg['LOSTPASSWORD_CAPTCHA_FONTS'][mt_rand(
                 0, count($cfg['LOSTPASSWORD_CAPTCHA_FONTS']) - 1
             )];

--- a/gui/public/imagecode.php
+++ b/gui/public/imagecode.php
@@ -26,6 +26,6 @@
  */
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/LostPassword.php';
+require_once 'LostPassword.php';
 
 createImage('capcode');

--- a/gui/public/lostpassword.php
+++ b/gui/public/lostpassword.php
@@ -33,7 +33,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/LostPassword.php';
+require_once 'LostPassword.php';
 
 EventAggregator::getInstance()->dispatch(Events::onLostPasswordScriptStart);
 do_session_timeout();


### PR DESCRIPTION
Fix paths for lostpassword

- Fix case in gui/resources/fonts
- Fix location of resources gui/resources rather than library/...
- LostPassword.php can be found in the include path, so remove
  the LIBRARY_PATH prefix.