### PR TITLE
Fix missing back tick in PhpEditor.php

### DIFF
--- a/gui/src/PhpEditor.php
+++ b/gui/src/PhpEditor.php
@@ -1177,7 +1177,7 @@ class PhpEditor
                     $query = "
                         UPDATE `subdomain`
                         JOIN `domain` USING(domain_id)
-                        SET subdomain_status` = 'tochange'
+                        SET `subdomain_status` = 'tochange'
                         WHERE `domain_admin_id` = ?
                         AND `subdomain_id` = ?
                         AND `subdomain_status` NOT IN ('disabled','todelete')


### PR DESCRIPTION
- Missing backtick in updating php settings for subdomains.