### PR TITLE
make sure to add ipv4 of host before ipv6

### DIFF
--- a/autoinstaller/Packages/debian-buster.xml
+++ b/autoinstaller/Packages/debian-buster.xml
@@ -464,29 +464,29 @@
             description="SQL server"
             has_alternatives="1"
     >
-        <mariadb_10.3
+        <mariadb_10.4
                 allow_upgrade_from="
                     remote_server,mariadb_10.0,mariadb_10.1,mariadb_10.2
                 "
                 class="Servers::sqld::mariadb"
                 default="1"
-                description="MariaDB 10.3"
+                description="MariaDB 10.4"
                 pinning_package="
-                    libmariadb3 mariadb-client-10.3 mariadb-common
-                    mariadb-server-core-10.3 mysql-common
+                    libmariadb3 mariadb-client-10.4 mariadb-common
+                    mariadb-server-core-10.4 mysql-common
                 "
                 pinning_pin="release o=Debian"
                 pinning_pin_priority="1001"
         >
             <package>libmariadb3</package>
-            <package>mariadb-client-10.3</package>
+            <package>mariadb-client-10.4</package>
             <package>mariadb-common</package>
             <package
                     pre_install_tasks="/bin/mkdir -p /etc/mysql/mariadb.conf.d"
             >
-                mariadb-server-10.3
+                mariadb-server-10.4
             </package>
-        </mariadb_10.3>
+        </mariadb_10.4>
         <remote_server
                 class="Servers::sqld::remote"
                 description="Remote SQL server"

--- a/engine/PerlLib/Servers/named/bind.pm
+++ b/engine/PerlLib/Servers/named/bind.pm
@@ -889,13 +889,19 @@ sub _addDmnDb
         $tplFileC
     );
     my $net = iMSCP::Net->getInstance();
-    my $domainIP = $net->isRoutableAddr( $data->{'DOMAIN_IP'} )
+    my $domainIP = ($net->isRoutableAddr( $data->{'DOMAIN_IP'} ) && $net->getAddrVersion($data->{'DOMAIN_IP'}) eq 'ipv4')
         ? $data->{'DOMAIN_IP'}
         : $data->{'BASE_SERVER_PUBLIC_IP'};
+    my $domainIP6 = $net->getAddrVersion( $data->{'DOMAIN_IP'} ) eq 'ipv6'
+        ? $data->{'DOMAIN_IP'}
+        : "none";
 
     unless ( $nsRRb eq '' && $gRRb eq '' ) {
         my @nsIPs = (
             $domainIP,
+            ( $domainIP6 ne "none"
+                ? $domainIP6 : ()
+            ),
             ( $self->{'config'}->{'SECONDARY_DNS'} eq 'no'
                 ? () : split /(?:[;,]| )/, $self->{'config'}->{'SECONDARY_DNS'}
             )

--- a/gui/include/Tickets.php
+++ b/gui/include/Tickets.php
@@ -186,7 +186,7 @@ function updateTicket(
             $ticketTo = $row['ticket_from'];
             $ticketFrom = $row['ticket_to'];
         }
-
+        $ticketStatus = $row['ticket_status'];
         exec_query(
             '
                 INSERT INTO tickets (
@@ -197,7 +197,7 @@ function updateTicket(
                 )
              ',
             [
-                $ticketFrom, $ticketTo, NULL, $ticketId, $urgency, time(),
+                $ticketFrom, $ticketTo, $ticketStatus, $ticketId, $urgency, time(),
                 $subject, $userMessage
             ]
         );

--- a/gui/public/admin/ticket_closed.php
+++ b/gui/public/admin/ticket_closed.php
@@ -31,7 +31,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('admin');
 EventAggregator::getInstance()->dispatch(Events::onAdminScriptStart);

--- a/gui/public/admin/ticket_delete.php
+++ b/gui/public/admin/ticket_delete.php
@@ -29,7 +29,7 @@ use iMSCP\Event\EventAggregator;
 use iMSCP\Event\Events;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('admin');
 EventAggregator::getInstance()->dispatch(Events::onAdminScriptStart);

--- a/gui/public/admin/ticket_system.php
+++ b/gui/public/admin/ticket_system.php
@@ -31,7 +31,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('admin');
 EventAggregator::getInstance()->dispatch(Events::onAdminScriptStart);

--- a/gui/public/admin/ticket_view.php
+++ b/gui/public/admin/ticket_view.php
@@ -30,7 +30,7 @@ use iMSCP\Event\Events;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('admin');
 EventAggregator::getInstance()->dispatch(Events::onAdminScriptStart);

--- a/gui/public/client/ticket_closed.php
+++ b/gui/public/client/ticket_closed.php
@@ -31,7 +31,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('user');
 EventAggregator::getInstance()->dispatch(Events::onClientScriptStart);

--- a/gui/public/client/ticket_create.php
+++ b/gui/public/client/ticket_create.php
@@ -30,7 +30,7 @@ use iMSCP\Event\Events;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('user');
 EventAggregator::getInstance()->dispatch(Events::onClientScriptStart);

--- a/gui/public/client/ticket_delete.php
+++ b/gui/public/client/ticket_delete.php
@@ -29,7 +29,7 @@ use iMSCP\Event\EventAggregator;
 use iMSCP\Event\Events;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('user');
 EventAggregator::getInstance()->dispatch(Events::onClientScriptStart);

--- a/gui/public/client/ticket_system.php
+++ b/gui/public/client/ticket_system.php
@@ -31,7 +31,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('user');
 EventAggregator::getInstance()->dispatch(Events::onClientScriptStart);

--- a/gui/public/client/ticket_view.php
+++ b/gui/public/client/ticket_view.php
@@ -30,7 +30,7 @@ use iMSCP\Event\Events;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('user');
 EventAggregator::getInstance()->dispatch(Events::onClientScriptStart);

--- a/gui/public/reseller/ticket_closed.php
+++ b/gui/public/reseller/ticket_closed.php
@@ -31,7 +31,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('reseller');
 EventAggregator::getInstance()->dispatch(Events::onResellerScriptStart);

--- a/gui/public/reseller/ticket_create.php
+++ b/gui/public/reseller/ticket_create.php
@@ -30,7 +30,7 @@ use iMSCP\Event\Events;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('reseller');
 EventAggregator::getInstance()->dispatch(Events::onResellerScriptStart);

--- a/gui/public/reseller/ticket_delete.php
+++ b/gui/public/reseller/ticket_delete.php
@@ -29,7 +29,7 @@ use iMSCP\Event\EventAggregator;
 use iMSCP\Event\Events;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('reseller');
 EventAggregator::getInstance()->dispatch(Events::onResellerScriptStart);

--- a/gui/public/reseller/ticket_system.php
+++ b/gui/public/reseller/ticket_system.php
@@ -31,7 +31,7 @@ use iMSCP\Registry;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('reseller');
 EventAggregator::getInstance()->dispatch(Events::onResellerScriptStart);

--- a/gui/public/reseller/ticket_view.php
+++ b/gui/public/reseller/ticket_view.php
@@ -30,7 +30,7 @@ use iMSCP\Event\Events;
 use iMSCP\TemplateEngine;
 
 require_once 'imscp-lib.php';
-require_once LIBRARY_PATH . '/Functions/Tickets.php';
+require_once GUI_ROOT_DIR . '/include/Tickets.php';
 
 check_login('reseller');
 EventAggregator::getInstance()->dispatch(Events::onResellerScriptStart);


### PR DESCRIPTION
**Issue:**

On a node that has a dual stack connection, with ipv6 being the first, and with defined v4 slaves, you end up having v4 ns1 and ns2 as slaves and a v6 ns1 that points to the i-MSCP node.

**Intended fix:**
Get the v4 IP from BASE_SERVER_PUBLIC_IP if the main DOMAIN_IP is v6 and then add the v6 ip immediately after the v4 one.

This should provide us with a final dns alike:

```
ns1 IN A 1.2.3.4
ns2 IN A 1.2.3.5
ns1 IN AAAA aa:ee:...
```

