### PR TITLE
Add support for host names that contain underscores, e.g. DKIM records

### DIFF
--- a/gui/public/client/dns_edit.php
+++ b/gui/public/client/dns_edit.php
@@ -153,7 +153,7 @@ function client_validate_NAME($name, &$errorString)
         return false;
     }
 
-    // rg 2024-02-20: Allow hostnames to contain `_` and `*.`, therefore remove these strings.
+    // rg 2024-02-20: Allow hostnames to contain `_` and `*.`, so remove these strings for validation.
     $name = str_replace('_', '', $name);
     $name = str_replace('*.', '', $name);
 

--- a/gui/public/client/dns_edit.php
+++ b/gui/public/client/dns_edit.php
@@ -153,14 +153,17 @@ function client_validate_NAME($name, &$errorString)
         return false;
     }
 
+    // rg 2024-02-20: Allow hostnames to contain `_` and `*.`, therefore remove these strings.
+    $name = str_replace('_', '', $name);
+    $name = str_replace('*.', '', $name);
 
-    if (strpos($name, '_') == 0) {
-        $name = substr($name, 1);
-    }
+    // if (strpos($name, '_') === 0) {
+    //     $name = substr($name, 1);
+    // }
 
-    if (strpos($name, '*.') == 0) {
-        $name = substr($name, 2);
-    }
+    // if (strpos($name, '*.') === 0) {
+    //     $name = substr($name, 2);
+    // }
 
     if (!isValidDomainName($name)) {
         $errorString .= tr('Invalid field: %s', tr('Name'));

--- a/gui/public/client/dns_edit.php
+++ b/gui/public/client/dns_edit.php
@@ -153,17 +153,13 @@ function client_validate_NAME($name, &$errorString)
         return false;
     }
 
-    // rg 2024-02-20: Allow hostnames to contain `_` and `*.`, so remove these strings for validation.
+    // Allow hostnames to contain `_`, e.g. `default._domainkey.example.com`
     $name = str_replace('_', '', $name);
-    $name = str_replace('*.', '', $name);
 
-    // if (strpos($name, '_') === 0) {
-    //     $name = substr($name, 1);
-    // }
-
-    // if (strpos($name, '*.') === 0) {
-    //     $name = substr($name, 2);
-    // }
+    // Allow wildcard hostnames at the beginning only.
+    if (strpos($name, '*.') === 0) {
+        $name = substr($name, 2);
+    }
 
     if (!isValidDomainName($name)) {
         $errorString .= tr('Invalid field: %s', tr('Name'));


### PR DESCRIPTION
The validation of host names fails for names like `default._domainkey.example.com`, because underscores were only removed from the beginning of host names. Also changed equals check to identity check, so wildcards are only allowed at the beginning.