### PR TITLE
strpos breaks validation for 3 chars subdomains

### DIFF
--- a/gui/public/client/dns_edit.php
+++ b/gui/public/client/dns_edit.php
@@ -154,11 +154,11 @@ function client_validate_NAME($name, &$errorString)
     }
 
 
-    if (strpos($name, '_') == 0) {
+    if (strpos($name, '_') === 0) {
         $name = substr($name, 1);
     }
 
-    if (strpos($name, '*.') == 0) {
+    if (strpos($name, '*.') === 0) {
         $name = substr($name, 2);
     }
 


### PR DESCRIPTION
Because of the way strpos works, checking if position is 0 may also match when strpos returns false, unless using `===`.

See:
https://www.php.net/manual/en/function.strpos.php
https://www.php.net/manual/en/language.operators.comparison.php